### PR TITLE
ResolverContract now expects a JSON object at contructor. Improved docs and ES6 using

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var Web3 = require('web3');
-var namehash = require('eth-ens-namehash')
+const Web3 = require('web3');
+const namehash = require('eth-ens-namehash')
 const defaultAbi = require('./json/resolver.json');
 const defaultNode = "https://public-node.testnet.rsk.co";
 const defaultResolverAddress = "0x59313581e7d735793962e16b8d0b10636bf53ae7"
@@ -38,36 +38,36 @@ class ResolverContract {
 		this.web3 = new Web3(nodeProvider);
 		this.address = resolverAddress;	
 		this.abi = resolverAbi;
-		this.resolverContract = new this.web3.eth.Contract(JSON.parse(this.abi), this.address);
+		this.resolverContract = new this.web3.eth.Contract(this.abi, this.address);
 	}
 
 	/**
 	 * Returns the address associated with an RNS node.
 	 * or 0x00 if address is not set.
 	 * @param {string} nameDomain 
-	 * @returns {object} A promise for the contract instance.
+	 * @returns {Promise<string>} A promise for the contract instance. The address associated with the nameDomain
 	 */
 
 	addr(nameDomain) {
-		return this.resolverContract.methods.addr(this.getNode(nameDomain)).call();
+		return this.resolverContract.methods.addr(ResolverContract.getNode(nameDomain)).call();
 	}
 
 	/**
 	 * Returns true if the specified node has the specified record type.
 	 * @param {string} nameDomain The RNS' name domain to query.
      * @param {string} kind The record type name, as specified in RNSIP01.
-     * @return {bool} True if this resolver has a record of the provided type on the
+     * @return {Promise<boolean>} True if this resolver has a record of the provided type on the
      *         provided node.
 	 */
 
 	has(nameDomain, kind) {
-		return this.resolverContract.methods.has(this.getNode(nameDomain), this.web3.utils.asciiToHex(kind)).call();
+		return this.resolverContract.methods.has(ResolverContract.getNode(nameDomain), this.web3.utils.asciiToHex(kind)).call();
 	}
 
 	/**
      * Returns true if the resolver implements the interface specified by the provided interfaceID (hash).
      * @param {string} interfaceID The ID (hash) of the interface to check for.
-     * @return {bool} True if the contract implements the requested interface.
+     * @return {Promise<boolean>} True if the contract implements the requested interface.
      */
 
 	supportsInterface(interfaceID) {
@@ -80,10 +80,11 @@ class ResolverContract {
      * @param {string} nameDomain The domain to update.
      * @param {address} addr The address to set.
      * @param fromAccount The spender address
+	 * @return {Promise<void>}
      */
 
 	setAddr(nameDomain, addr, fromAccount){
-		return this.resolverContract.methods.setAddr(this.getNode(nameDomain), addr).send({from: fromAccount})
+		return this.resolverContract.methods.setAddr(ResolverContract.getNode(nameDomain), addr).send({from: fromAccount})
 	}
 
 	/**
@@ -92,21 +93,22 @@ class ResolverContract {
      * @param {string} nameDomain The domain to update.
      * @param hash The address to set.
      * @param {address} fromAccount The spender address
-     */
+	 * @return {Promise<void>}
+	 */
 
 	setContent(nameDomain, hash, fromAccount){
-		return this.resolverContract.methods.setContent(this.getNode(nameDomain), hash).send({from: fromAccount})
+		return this.resolverContract.methods.setContent(ResolverContract.getNode(nameDomain), hash).send({from: fromAccount})
 	}
 
 	/**
 	 * Returns the hash associated with an RNS domain.
 	 * or 0x00 if hash is not set.
 	 * @param {string} nameDomain 
-	 * @returns {object} A promise for the contract instance.
+	 * @returns {Promise<void>} A promise for the contract instance.
 	 */
 	
 	content(nameDomain){
-		return this.resolverContract.methods.content(this.getNode(nameDomain)).call();
+		return this.resolverContract.methods.content(ResolverContract.getNode(nameDomain)).call();
 	}
 
 	/**
@@ -115,7 +117,7 @@ class ResolverContract {
 	 * @returns {hash} The name hash
 	 */
 
-	getNode (nameDomain) {
+	static getNode (nameDomain) {
 		return namehash.hash(nameDomain);
 	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,37 +1,36 @@
-var assert = require('assert');
-var async = require('async');
-var fs = require('fs');
-var solc = require('solc')
-var Web3 = require('web3');
-var Resolver = require('./../index.js')
-var namehash = require('eth-ens-namehash')
-var aHash = "0x89ad40fcd44690fb5aa90e0fa51637c1b2d388f8056d68430d41c8284a6a7d5e";
+const assert = require('assert');
+const fs = require('fs');
+const solc = require('solc');
+const Web3 = require('web3');
+const Resolver = require('./../index.js');
+const namehash = require('eth-ens-namehash');
+const aHash = "0x89ad40fcd44690fb5aa90e0fa51637c1b2d388f8056d68430d41c8284a6a7d5e";
 
 
 describe('Resolver', function () {
-	var resolver = null;
-	var hashForTest = null;
+	let resolver = null;
+	let hashForTest = null;
 	beforeEach( async () => {
-		var web3 = new Web3();
+		let web3 = new Web3();
 		hashForTest = web3.utils.randomHex(32);
 		this.ctx.timeout(20000);
 		//web3.setProvider(TestRPC.provider());
 		try {
 			web3.setProvider(new web3.providers.HttpProvider('http://localhost:8545'));
 			accounts = await web3.eth.getAccounts();
-			var input = {
+			const input = {
 				'AbstractRNS.sol' : fs.readFileSync('test/contracts/AbstractRNS.sol').toString(),
 				'RNS.sol' : fs.readFileSync('test/contracts/RNS.sol').toString(),
 				'ResolverInterface.sol' : fs.readFileSync('test/contracts/ResolverInterface.sol').toString(),
 				'PublicResolver.sol' : fs.readFileSync('test/contracts/PublicResolver.sol').toString()
 			};
-			var compiled = solc.compile({sources:input}, 1);
+			const compiled = solc.compile({sources:input}, 1);
 			assert.equal(compiled.errors, undefined);
 
 			// Deploy the RNS contract
 		
-			var deployer = compiled.contracts['RNS.sol:RNS'];			
-			var deployRNSContract = new web3.eth.Contract(JSON.parse(deployer.interface));
+			let deployer = compiled.contracts['RNS.sol:RNS'];
+			const deployRNSContract = new web3.eth.Contract(JSON.parse(deployer.interface));
 			rnsContract = await deployRNSContract.deploy({
 					data: deployer.bytecode
 				})
@@ -45,9 +44,9 @@ describe('Resolver', function () {
 			}
 			// Deploy the PublicResolver contract
 			deployer = compiled.contracts['PublicResolver.sol:PublicResolver'];
-			var resolverABI = fs.readFileSync('json/resolver.json').toString();
-			var deployResolverContract = new web3.eth.Contract(JSON.parse(resolverABI));
-			resolverContract = await deployResolverContract.deploy({
+			const resolverABI = JSON.parse(fs.readFileSync('json/resolver.json').toString());
+			const deployResolverContract = new web3.eth.Contract(resolverABI);
+			const resolverContract = await deployResolverContract.deploy({
 						data: deployer.bytecode,
 						arguments: [rnsContract._address.toString()]
 				})
@@ -56,13 +55,13 @@ describe('Resolver', function () {
 					gas: 6700000,
 					gasPrice: 1000000
 				});
-			resolverAddress = resolverContract.options.address;
+			const resolverAddress = resolverContract.options.address;
 			if (resolverAddress == undefined) {
 				assert.ifError("Contract address is null", contract);
 			}
-			var tldHash = web3.utils.sha3('rsk');
-			var fooHash = web3.utils.sha3('foo');
-			var nodeFooDotRsk = namehash.hash('foo.rsk');
+			const tldHash = web3.utils.sha3('rsk');
+			const fooHash = web3.utils.sha3('foo');
+			const  nodeFooDotRsk = namehash.hash('foo.rsk');
 			await rnsContract.methods.setSubnodeOwner(namehash.hash(0), tldHash, accounts[0]).send({from: accounts[0]});
 			await rnsContract.methods.setSubnodeOwner(namehash.hash('rsk'), fooHash, accounts[0]).send({from: accounts[0]})
 			await rnsContract.methods.setResolver(nodeFooDotRsk, resolverAddress).send({from: accounts[0]});
@@ -77,7 +76,7 @@ describe('Resolver', function () {
 
 	it('should implement setAddr', async () => {
 		await resolver.setAddr('foo.rsk', accounts[1], accounts[0]);
-		result = await resolver.addr('foo.rsk');
+		const result = await resolver.addr('foo.rsk');
 		assert.equal(result, accounts[1]);
 		
 	});
@@ -92,8 +91,8 @@ describe('Resolver', function () {
 		
 	});
 	it('should implement setContent', async () => {
-		var testingHash = await resolver.setContent('foo.rsk', aHash, accounts[0]);
-		result = await resolver.content('foo.rsk');
+		const testingHash = await resolver.setContent('foo.rsk', aHash, accounts[0]);
+		const result = await resolver.content('foo.rsk');
 		assert.equal(result, aHash);
 		
 	});
@@ -103,7 +102,7 @@ describe('Resolver', function () {
 		} catch (ex) {
 			const expectedMsg = "VM Exception while processing transaction: revert";
 			const msg = typeof ex === "string" ? ex : ex.message;
-			assert.ok(msg.indexOf(expectedMsg) != -1);
+			assert.ok(msg.indexOf(expectedMsg) !== -1);
 		}
 		
 	});
@@ -114,33 +113,33 @@ describe('Resolver', function () {
 	});
 	
 	it('should implement has() with hash', async () => {
-		result = await resolver.has('foo.rsk', 'hash');
+		const result = await resolver.has('foo.rsk', 'hash');
 		assert.equal(result, true);
 		
 });
 	it('has() with function not implemented', async () => {
-		result = await resolver.has('foo.rsk', 'boom');
+		const result = await resolver.has('foo.rsk', 'boom');
 		assert.equal(result, false);
 		
 	});
 
 	it('should resolve names', async () => {
-		result = await resolver.addr('foo.rsk');
+		const result = await resolver.addr('foo.rsk');
 		assert.equal(result, accounts[0]);
 	});
 	
 	it('should resolve content', async () => {
-		result = await resolver.content('foo.rsk');
+		const result = await resolver.content('foo.rsk');
 		assert.equal(result, hashForTest);
 	});
 
 	it('shouldnt resolve names did not registered', async () => {
-		result = await resolver.addr('foo');
+		const result = await resolver.addr('foo');
 		assert.equal(result, 0);
 	});
 	
 	it('should implement supportsInterface', async () => {
-		 result = await resolver.supportsInterface("0x3b3b57de");
+		 let  result = await resolver.supportsInterface("0x3b3b57de");
 		 result &= await resolver.supportsInterface("0xd8389dc5");
 	 	assert.equal(result, true);
 	});


### PR DESCRIPTION
- Fix for https://github.com/rnsdomains/RNS-SDK-js/issues/2
- Improved docs for async functions
- Removed ´var´ keyword and some unused declared vars.
- getNode can be static since it does not uses ResolverContract members, its just a call to a library method.